### PR TITLE
ProfilePage test fixes after refactor and Edit card hotfix

### DIFF
--- a/client_web/src/components/CardList/Card.js
+++ b/client_web/src/components/CardList/Card.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { selectDraftCard } from "reducers/selectors";
+import { card } from "actions/cardActions";
 import CardForm from "components/CardForm";
 import PickList from "../PickList";
 
@@ -40,6 +41,6 @@ class Card extends React.Component {
   }
 }
 
-export default connect((state) => ({ draftCard: selectDraftCard(state) }))(
-  Card
-);
+export default connect((state) => ({ draftCard: selectDraftCard(state) }), {
+  setEditable: card.draft.set.editing,
+})(Card);

--- a/client_web/src/containers/ProfilePage/ProfilePage.test.js
+++ b/client_web/src/containers/ProfilePage/ProfilePage.test.js
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  getByTestId,
-  queryByText,
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from "testing/testUtils";
+import { render, screen, waitForElementToBeRemoved } from "testing/testUtils";
 import userEvent from "@testing-library/user-event";
 import { AuthProvider } from "testing/stubs/authProvider";
 
@@ -139,7 +133,6 @@ describe("<ProfilePage />", () => {
       it("can create card and add to profile", async () => {
         // it awaits loaded profile and cards
         await screen.findByRole("img", { name: "compass" });
-        await screen.findAllByRole("button", { name: "share icon" });
 
         // it opens form
         const newPostBtn = await screen.findByText("+ New Picks");
@@ -147,41 +140,30 @@ describe("<ProfilePage />", () => {
 
         // form field selectors
         const postCommentField = await screen.findByText(/post comments/i);
-        const titleField = await screen.findByRole("textbox", {
-          name: /title/i,
-        });
         const urlField = await screen.findByRole("textbox", { name: /url/i });
-        const picksCommentField = await screen.findByRole("textbox", {
-          name: "Comments",
-          exact: true,
-        });
+
         const submitBtn = await screen.findByRole("button", {
           name: /post picks/i,
         });
 
         userEvent.type(postCommentField, "CREATE_CARD_TEST1");
-        userEvent.type(titleField, "CREATE_CARD_TEST2");
         userEvent.type(urlField, "http://www.CREATE_CARD_TEST.com");
-        userEvent.type(picksCommentField, "CREATE_CARD_TEST3");
+
+        await waitForElementToBeRemoved(
+          () => screen.queryByText("Loading preview..."),
+          { timeout: 1100 }
+        );
 
         userEvent.click(submitBtn);
+
+        // it hides create form after submit
+        await waitForElementToBeRemoved(() =>
+          screen.queryByText("Create a Post")
+        );
 
         // it displays created post on page
         const postCommentText = await screen.findByText("CREATE_CARD_TEST1");
         expect(postCommentText).toBeInTheDocument();
-
-        const titleText = await screen.findByText("CREATE_CARD_TEST2");
-        expect(titleText).toBeInTheDocument();
-
-        const picksCommentText = await screen.findByText(
-          "comments: CREATE_CARD_TEST3"
-        );
-        expect(picksCommentText).toBeInTheDocument();
-
-        // it no longer displays create form
-        expect(
-          screen.queryByText("Create a picks post")
-        ).not.toBeInTheDocument();
       });
       it("can cancel creating card", async () => {
         const newPostBtn = await screen.findByText("+ New Picks");

--- a/client_web/src/containers/ProfilePage/ProfilePage.test.js
+++ b/client_web/src/containers/ProfilePage/ProfilePage.test.js
@@ -229,8 +229,9 @@ describe("<ProfilePage />", () => {
       expect(usersCard[0]).toContainHTML("Edit</button>");
 
       const otherUsersCard = await screen.findByRole("listitem", {
-        name: /card by some_other_user/i,
+        name: /card by A_DIFFERENT_USER/i,
       });
+
       expect(otherUsersCard).not.toContainHTML("Edit</button>");
     });
     it.todo("can update users card");

--- a/client_web/src/testing/mocks/cards/cards.mock.controllers.js
+++ b/client_web/src/testing/mocks/cards/cards.mock.controllers.js
@@ -24,12 +24,12 @@ export const cardsMockControllers = {
   },
   getLinkPreview: (req, res, ctx) => {
     const urlParam = req.url.searchParams.get("url");
-    const reqDomain = parseDomain(urlParam);
+    // const reqDomain = parseDomain(urlParam);
 
     const preview = {
       data: {
         ogType: "article",
-        ogTitle: `Mock preview to ${reqDomain}`,
+        ogTitle: `Mock preview`,
         ogLocale: "en",
         ogImage: {
           url: "https://miro.medium.com/max/1200/0*fNOHp2Ep8z9pwRnr",


### PR DESCRIPTION
- Fixes setting card editable, setEditable action was incorrectly removed from mapDispatch
- Fixes test Profile of authenticated user > can create card and add to profile, after refactor
- Fixes test Profile of authenticated user > does not show edit button if is not users card, after refactor
