### PR TITLE
Re-imlements move pick buttons

### DIFF
--- a/client_web/src/actionTypes/index.js
+++ b/client_web/src/actionTypes/index.js
@@ -27,6 +27,7 @@ export const CHANGE_DRAFT = "cardDraft/change";
 export const DRAFT_PICK = {
   add: "cardDraft/addPick",
   remove: "cardDraft/removePick",
+  move: "cardDraft/move",
 };
 export const GET_LINK_PREVIEW = createRequestTypes("cardForm/getLinkPreview");
 export const LINK_PREVIEW_NOT_FOUND = "cardForm/linkPreviewNotFound";

--- a/client_web/src/actions/cardActions.js
+++ b/client_web/src/actions/cardActions.js
@@ -64,6 +64,7 @@ export const card = {
     pick: {
       add: () => action(DRAFT_PICK.add, { id: uuid() }),
       remove: (id) => action(DRAFT_PICK.remove, { id }),
+      move: (fromId, toId) => action(DRAFT_PICK.move, { fromId, toId }),
     },
   },
 };

--- a/client_web/src/components/CardForm/EditingPick.js
+++ b/client_web/src/components/CardForm/EditingPick.js
@@ -1,7 +1,15 @@
 import React from "react";
 import Preview from "./Preview";
 
-const EditingPick = ({ pick, removePick, onChange }) => {
+const EditingPick = ({
+  pick,
+  removePick,
+  onChange,
+  onMoveUp,
+  onMoveDown,
+  isFirstPick,
+  isLastPick,
+}) => {
   const loadingPreview = pick.status === "loading";
 
   const displayPreviewNotFound =
@@ -58,11 +66,21 @@ const EditingPick = ({ pick, removePick, onChange }) => {
           />
         </label>
         <div>
-          <button aria-label="move-up" type="button" className="mx-2">
+          <button
+            aria-label="move-up"
+            type="button"
+            className={`mx-2${isFirstPick ? " invisible" : ""}`}
+            onClick={onMoveUp}
+          >
             ↑
           </button>
 
-          <button aria-label="move-down" type="button" className="mx-2">
+          <button
+            aria-label="move-down"
+            type="button"
+            className={`mx-2 ${isLastPick ? " invisible" : ""}`}
+            onClick={onMoveDown}
+          >
             ↓
           </button>
 

--- a/client_web/src/components/CardForm/EditingPicks.js
+++ b/client_web/src/components/CardForm/EditingPicks.js
@@ -6,18 +6,32 @@ import { card as cardActions } from "actions/cardActions";
 
 class EditingPicks extends React.Component {
   render() {
-    const { draftCard, addPick, removePick, handleChange } = this.props;
+    const { draftCard, addPick, removePick, handleChange, movePick } =
+      this.props;
 
     const { picks } = draftCard;
 
+    const handleMoveUp = (pickIndex) => {
+      if (pickIndex === 0) return;
+      movePick(picks[pickIndex]._id, picks[pickIndex - 1]._id);
+    };
+    const handleMoveDown = (pickIndex) => {
+      if (picks.length - 1 === pickIndex) return;
+      movePick(picks[pickIndex]._id, picks[pickIndex + 1]._id);
+    };
+
     return (
       <div>
-        {picks.map((pick) => (
+        {picks.map((pick, index) => (
           <EditingPick
             pick={pick}
             key={pick._id}
             removePick={() => removePick(pick._id)}
+            onMoveUp={() => handleMoveUp(index)}
+            onMoveDown={() => handleMoveDown(index)}
             onChange={(e) => handleChange(e, pick._id)}
+            isFirstPick={index === 0}
+            isLastPick={index === picks.length - 1}
           />
         ))}
         {picks.length < 5 ? (
@@ -44,6 +58,7 @@ const mapDispatch = {
   addPick: cardActions.draft.pick.add,
   removePick: cardActions.draft.pick.remove,
   handleChange: cardActions.draft.change,
+  movePick: cardActions.draft.pick.move,
 };
 
 export default connect(mapState, mapDispatch)(EditingPicks);

--- a/client_web/src/reducers/cardsReducer.js
+++ b/client_web/src/reducers/cardsReducer.js
@@ -164,7 +164,8 @@ const draftReducer = (state = null, action) => {
     }
 
     case DRAFT_PICK.move: {
-      // jank un-serialise/re-serialise implementation to save larger refactor to either only using un-serialised picks or moving to an actual normaliser library
+      // un-serialise/re-serialise implementation, refactor was attempted but didn't result in cleaner outcome as swapping elements of array or serialised object sucks in js sucks.
+
       const { fromId, toId } = action;
       if (!fromId || !toId) return state;
 

--- a/client_web/src/reducers/selectors.js
+++ b/client_web/src/reducers/selectors.js
@@ -1,4 +1,4 @@
-const denormalize = (normalizedObject) => Object.values(normalizedObject);
+import { denormalise } from "utils/normaliseArray";
 
 export const getIsAuthenticated = (state) => state.auth.isAuthenticated;
 export const getIsAuthenticating = (state) => state.auth.isAuthenticating;
@@ -6,16 +6,16 @@ export const selectUser = (state) => state.auth.user;
 
 export const getProfile = (state) => {
   const { cards, cardStatus, cardError, form } = state.profile.profileCards;
-  const denormalizedCards = denormalize(cards);
+  const denormalisedCards = denormalise(cards);
 
   return {
     profileHeader: state.profile.profileHeader,
-    profileCards: { cards: denormalizedCards, cardStatus, cardError, form },
+    profileCards: { cards: denormalisedCards, cardStatus, cardError, form },
   };
 };
 
 export const selectFormPicks = (state) =>
-  denormalize(state.profile.profileCards.form.picks);
+  denormalise(state.profile.profileCards.form.picks);
 
 export const selectCardFormVisibility = (state) =>
   state.profile.profileCards.form.visibility;
@@ -25,7 +25,7 @@ export const selectDraftCard = (state) => {
   const editing = draft ? { editing: !!draft?.editingId } : null;
 
   if (draft?.picks) {
-    const denormalisedPicks = denormalize(draft.picks);
+    const denormalisedPicks = denormalise(draft.picks);
     return { ...draft, picks: denormalisedPicks, ...editing };
   } else {
     return { ...draft, ...editing };

--- a/client_web/src/utils/normaliseArray.js
+++ b/client_web/src/utils/normaliseArray.js
@@ -3,3 +3,6 @@ export const normaliseArray = (arr) =>
     map[obj._id] = obj;
     return map;
   }, {});
+
+export const denormalise = (normalizedObject) =>
+  Object.values(normalizedObject);


### PR DESCRIPTION
- Moves denomaliser fn to own module
- Working Re-Implementation of moving picks Jank un-serialise/re-serialise implementation to save larger refactor to either only using un-serialised picks or moving to an actual normaliser library
- Comment change after attempting refactors (sad emoji)
